### PR TITLE
Closes #65 Improve error reporting based on user reproduction attempts

### DIFF
--- a/__run_exp7/KolakoskiSequenceTests.cs
+++ b/__run_exp7/KolakoskiSequenceTests.cs
@@ -1,0 +1,31 @@
+using Algorithms.Sequences;
+
+namespace Algorithms.Tests.Sequences;
+
+public class KolakoskiSequenceTests
+{
+    [Test]
+    public void First100ElementsCorrect()
+    {
+        // Taken from https://oeis.org/A000002
+        BigInteger[] expected =
+        [
+            1, 2, 2, 1, 1, 2, 1, 2, 2, 1,
+            2, 2, 1, 1, 2, 1, 1, 2, 2, 1,
+            2, 1, 1, 2, 1, 2, 2, 1, 1, 2,
+            1, 1, 2, 1, 2, 2, 1, 2, 2, 1,
+            1, 2, 1, 2, 2, 1, 2, 1, 1, 2,
+            1, 1, 2, 2, 1, 2, 2, 1, 1, 2,
+            1, 2, 2, 1, 2, 2, 1, 1, 2, 1,
+            1, 2, 1, 2, 2, 1, 2, 1, 1, 2,
+            2, 1, 2, 2, 1, 1, 2, 1, 2, 2,
+            1, 2, 2, 1, 1, 2, 1, 1, 2, 2,
+        ];
+
+        var sequence = new KolakoskiSequence().Sequence.Take(100);
+        var sequence2 = new KolakoskiSequence2().Sequence.Take(100);
+
+        sequence.Should().Equal(expected);
+        sequence2.Should().Equal(expected);
+    }
+}

--- a/__run_exp7/binary_search.md
+++ b/__run_exp7/binary_search.md
@@ -1,0 +1,37 @@
+
+
+``` r
+binary_search <- function(arr, target) { #function for finding position of value 
+  low <- 1
+  high <- length(arr) 
+  
+  while (low <= high) {
+    mid <- low + (high - low) %/% 2 #finding mid of array
+    
+    if (arr[mid] == target) { #comapring the mis value with the value to search
+      return(mid)  # Target found, return its index
+    } else if (arr[mid] < target) {
+      low <- mid + 1  # Search in the right half
+    } else {
+      high <- mid - 1  # Search in the left half
+    }
+  }
+  return(-1)  # Target not found in the array
+}
+
+arr <- c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10) #input array (hard code)
+target <- 7 #input value to be searched (hard code)
+
+result <- binary_search(arr, target) #binary_seach function calling
+
+if (result == -1) {
+  cat("Element", target, "not found in the array.\n")
+} else {
+  cat("Element", target, "found at position", result, ".\n")
+}
+```
+
+```
+## Element 7 found at position 7 .
+```
+

--- a/__run_exp7/mode.go
+++ b/__run_exp7/mode.go
@@ -1,0 +1,47 @@
+// mode.go
+// author(s): [CalvinNJK] (https://github.com/CalvinNJK)
+// time complexity: O(n)
+// space complexity: O(n)
+// description: Finding Mode Value In an Array
+// see mode.go
+
+package math
+
+import (
+	"errors"
+
+	"github.com/TheAlgorithms/Go/constraints"
+)
+
+// ErrEmptySlice is the error returned by functions in math package when
+// an empty slice is provided to it as argument when the function expects
+// a non-empty slice.
+var ErrEmptySlice = errors.New("empty slice provided")
+
+func Mode[T constraints.Number](numbers []T) (T, error) {
+
+	countMap := make(map[T]int)
+
+	n := len(numbers)
+
+	if n == 0 {
+		return 0, ErrEmptySlice
+	}
+
+	for _, number := range numbers {
+		countMap[number]++
+	}
+
+	var mode T
+	count := 0
+
+	for k, v := range countMap {
+		if v > count {
+			count = v
+			mode = k
+		}
+	}
+
+	return mode, nil
+
+}

--- a/__run_exp7/xgboost.r
+++ b/__run_exp7/xgboost.r
@@ -1,0 +1,19 @@
+library(tidyverse)
+library(xgboost)
+
+ind<-sample(2,nrow(diamonds),replace = T,prob = c(0.7,0.3))
+train.set<-diamonds[ind==1,]
+test.set<-diamonds[ind==2,]
+
+xgb.train<-bind_cols(select_if(train.set,is.numeric),model.matrix(~cut-1,train.set) %>% as.tibble(),model.matrix(~color-1,train.set) %>% as.tibble(),model.matrix(~clarity-1,train.set) %>% as.tibble())
+xgboost.train<-xgb.DMatrix(data = as.matrix(select(xgb.train,-price)),label=xgb.train$price)
+xgb.test<-bind_cols(select_if(test.set,is.numeric),model.matrix(~cut-1,test.set) %>% as.tibble(),model.matrix(~color-1,test.set) %>% as.tibble(),model.matrix(~clarity-1,test.set) %>% as.tibble())
+xgboost.test<-xgb.DMatrix(data = select(xgb.test,-price) %>% as.matrix(),label=xgb.test$price)
+
+param<-list(eval_metric='rmse',gamma=1,max_depth=6,nthread = 3)
+xg.model<-xgb.train(data = xgboost.train,params = param,watchlist = list(test=xgboost.test),nrounds = 500,early_stopping_rounds = 60,
+                      print_every_n = 30)
+                      
+xg.predict<-predict(xg.model,xgboost.test)
+mse.xgb<-sqrt(mean((test.set$price-xg.predict)^2))
+plot((test.set$price-xg.predict))


### PR DESCRIPTION
65 This issue has been marked as wontfix because supporting the legacy data format would require maintaining compatibility layers that add significant complexity and testing burden. The format was deprecated in 2020 with a two-year migration period.